### PR TITLE
Add check for draft page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -10,12 +10,14 @@
                 <div class="listing_title">{{ .Key }}</div>
                 <div class="listing">
                     {{ range .Pages }}
+                    {{ if not .Draft }}
                     <div class="listing_item">
                         <div class="listing_post">
                             <a href="{{ .RelPermalink }}">{{ .Title }}</a>
                             <div class="post_time"><span class="date">{{ .Date.Format "01-02" }}</span></div>
                         </div>
                     </div>
+                    {{ end }}
                     {{ end }}
                 </div>
                 {{ end }}

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,5 +1,6 @@
 {{ $paginator := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
 {{ range $paginator.Pages }}
+{{ if not .Draft }}
 <div class="post animated fadeInDown">
     <div class="post_title">
         <h2><a href='{{ .RelPermalink }}'>{{ .Title }}</a></h2>
@@ -30,6 +31,7 @@
         </div>
     </div>
 </div>
+{{ end }}
 {{ end }}
 
 <div class="pagination">


### PR DESCRIPTION
To hide pages.

Issue related: https://github.com/varkai/hugo-theme-zozo/issues/13

From [here](https://github.com/digitalcraftsman/hugo-cactus-theme/issues/57) I read that `hidden: true` might be deprecated, but can't find link related in hugo repo.

I tried to hide some pages too, but seem failed to hide them using `hidden: true`.

I read from [this](https://gohugo.io/variables/page/) looks like the only way to hide page is to use `.Draft`.